### PR TITLE
ENH: Make eclroot argument optional in `Grid3dAverageMap` and `Grid3dHcThickness` forward_model jobs

### DIFF
--- a/src/grid3d_maps/avghc/_get_grid_props.py
+++ b/src/grid3d_maps/avghc/_get_grid_props.py
@@ -50,6 +50,9 @@ def files_to_import(config, appname):
             initlist["xhcpv"] = config["input"]["xhcpv"]
 
         else:
+            if eclroot is None:
+                raise ValueError("'eclroot' information is not provided")
+
             initlist["PORO"] = eclroot + ".INIT"
             initlist["NTG"] = eclroot + ".INIT"
             initlist["PORV"] = eclroot + ".INIT"

--- a/src/grid3d_maps/forward_models/grid3d_aggregate_map.py
+++ b/src/grid3d_maps/forward_models/grid3d_aggregate_map.py
@@ -41,5 +41,8 @@ class Grid3dAggregateMap(ForwardModelStepPlugin):
 .. code-block:: console
 
   FORWARD_MODEL GRID3D_AGGREGATE_MAP(<CONFIG_AGGREGATE>=conf.yml, <ECLROOT>=<ECLBASE>)
+
+where ECLBASE is already defined in your ERT config, pointing to the Eclipse/Flow
+basename relative to RUNPATH.
 """,
         )

--- a/src/grid3d_maps/forward_models/grid3d_average_map.py
+++ b/src/grid3d_maps/forward_models/grid3d_average_map.py
@@ -20,6 +20,9 @@ class Grid3dAverageMap(ForwardModelStepPlugin):
                 "--eclroot",
                 "<ECLROOT>",
             ],
+            default_mapping={
+                "<ECLROOT>": "",
+            },
         )
 
     def validate_pre_realization_run(
@@ -38,8 +41,15 @@ class Grid3dAverageMap(ForwardModelStepPlugin):
             source_function_name="Grid3dAverageMap",
             description=DESCRIPTION,
             examples="""
+Following is an example for extracting maps from the flow simulation grid
 .. code-block:: console
 
   FORWARD_MODEL GRID3D_AVERAGE_MAP(<CONFIG_AVGMAP>=conf.yml, <ECLROOT>=<ECLBASE>)
+
+where ECLBASE is already defined in your ERT config, pointing to the Eclipse/Flow
+basename relative to RUNPATH.
+
+.. note:: The <ECLROOT> argument is optional and can be omitted if sufficient
+information is provided in the config, e.g. when extracting maps from a geological grid.
 """,
         )

--- a/src/grid3d_maps/forward_models/grid3d_hc_thickness.py
+++ b/src/grid3d_maps/forward_models/grid3d_hc_thickness.py
@@ -20,6 +20,9 @@ class Grid3dHcThickness(ForwardModelStepPlugin):
                 "--eclroot",
                 "<ECLROOT>",
             ],
+            default_mapping={
+                "<ECLROOT>": "",
+            },
         )
 
     def validate_pre_realization_run(
@@ -38,8 +41,15 @@ class Grid3dHcThickness(ForwardModelStepPlugin):
             source_function_name="Grid3dHcThickness",
             description=DESCRIPTION,
             examples="""
+Following is an example for extracting maps from the flow simulation grid
 .. code-block:: console
 
   FORWARD_MODEL GRID3D_HC_THICKNESS(<CONFIG_HCMAP>=conf.yml, <ECLROOT>=<ECLBASE>)
+
+where ECLBASE is already defined in your ERT config, pointing to the Eclipse/Flow
+basename relative to RUNPATH.
+
+.. note:: The <ECLROOT> argument is optional and can be omitted if sufficient
+information is provided in the config, e.g. when extracting maps from a geological grid.
 """,
         )

--- a/src/grid3d_maps/forward_models/grid3d_migration_time.py
+++ b/src/grid3d_maps/forward_models/grid3d_migration_time.py
@@ -41,5 +41,8 @@ class Grid3dMigrationTime(ForwardModelStepPlugin):
 .. code-block:: console
 
   FORWARD_MODEL GRID3D_MIGRATION_TIME(<CONFIG_MIGTIME>=conf.yml, <ECLROOT>=<ECLBASE>)
+
+where ECLBASE is already defined in your ERT config, pointing to the Eclipse/Flow
+basename relative to RUNPATH.
 """,
         )


### PR DESCRIPTION
Resolves #49 

Fixed by setting the `<ECLROOT>` argument for the `Grid3dAverageMap` and `Grid3dHcThickness` forward_model jobs to an empty string, which in turn prevents triggering the update here:
https://github.com/equinor/grid3d-maps/blob/9dff6d1e81d1d72a58613c2938d478b14d89e075/src/grid3d_maps/avghc/_configparser.py#L327-L328