### PR TITLE
CI: Test with ert in test dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,7 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            python-version: 3.8
-          - os: windows-latest
-            python-version: 3.8
+            python-version: 3.11
     runs-on: ${{ matrix.os }}
     env:
       MPLBACKEND: Agg
@@ -48,36 +46,4 @@ jobs:
         run: pip freeze
 
       - name: Run test
-        run: pytest -n 4 tests/test_scripts --disable-warnings
-
-  test_vs_ert:
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    env:
-      MPLBACKEND: Agg
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install grid3d-maps
-        run: |
-          pip install -U pip
-          pip install ".[tests]"
-
-      - name: List all installed packages
-        run: pip freeze
-
-      - name: Run test vs ERT
-        run: |
-          pip install ert
-          pytest -n auto tests/test_vs_ert --disable-warnings
+        run: pytest -n auto --disable-warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,13 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
     "coverage>=4.1",
+    "ert; sys_platform != 'win32'",
     "ruff",
     "mypy",
     "pylint",
     "pytest",
     "pytest-cov",
+    "PyQt5-sip<12.16.0; python_version == '3.8'",
     "pytest-runner",
     "pytest-xdist",
     "rstcheck",

--- a/tests/test_vs_ert/test_ert_hooks.py
+++ b/tests/test_vs_ert/test_ert_hooks.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+pytest.importorskip("ert")
+
 XTGEOTESTDATA = "tests/data/reek"
 ECLROOT = "tests/data/reek/REEK"
 


### PR DESCRIPTION
This removes the secondary ert-only CI jobs and tests everything together. That might not categorically be an improvement, but it seems to run everything a bit faster.

After moving to Python 3.11 for windows, the tests were taking over an hour to complete, so it was dropped in this PR.